### PR TITLE
Modify Landsat URL generation to fall through data sources for L1GT

### DIFF
--- a/landsat/landsat.go
+++ b/landsat/landsat.go
@@ -35,7 +35,7 @@ func IsPreCollectionDataType(dataType string) bool {
 	return false
 }
 
-var collection1DataTypes = []string{"L1TP"}
+var collection1DataTypes = []string{"L1TP", "L1GT", "L1GS"}
 
 // IsCollection1DataType returns whether a data type is a "Collection 1" type
 // Reference: https://landsat.usgs.gov/landsat-processing-details

--- a/landsat/scenes.go
+++ b/landsat/scenes.go
@@ -123,20 +123,24 @@ func GetSceneFolderURL(sceneID string, dataType string) (folderURL string, fileP
 		return "", "", fmt.Errorf("Invalid scene ID: %s", sceneID)
 	}
 
-	if IsPreCollectionDataType(dataType) {
-		return formatPreCollectionIDToURL(sceneID), sceneID, nil
-	}
-	if !IsCollection1DataType(dataType) {
+	isPreC1 := IsPreCollectionDataType(dataType)
+	isC1 := IsCollection1DataType(dataType)
+	if !(isPreC1 || isC1) {
 		return "", "", errors.New("Unknown LandSat data type: " + dataType)
 	}
 
-	if !SceneMapIsReady {
-		return "", "", errors.New("Scene map is not ready yet")
-	}
-	record, ok := sceneMap[sceneID]
-	if !ok {
-		return "", "", errors.New("Scene not found with ID: " + sceneID)
+	if isC1 {
+		if !SceneMapIsReady {
+			return "", "", errors.New("Scene map is not ready yet")
+		}
+		if record, ok := sceneMap[sceneID]; ok {
+			return record.awsFolderURL, record.filePrefix, nil
+		}
 	}
 
-	return record.awsFolderURL, record.filePrefix, nil
+	if isPreC1 {
+		return formatPreCollectionIDToURL(sceneID), sceneID, nil
+	}
+
+	return "", "", fmt.Errorf("Scene not found with ID: %s, dataType: %s", sceneID, dataType)
 }


### PR DESCRIPTION
This issue was due to the Landsat data type "L1GT" having an ambiguous
meaning as far as whether the scene is a Collection-1 scene or not. I
am changing the logic for obtaining Collection-1 to account for this
ambiguity by using the following logic instead:

1. if this is neither a Collection-1 scene nor a pre-Collection scene,
   return an error for unknown data type
2. if this is a Collection-1 scene, then try to look it up in the scene
   list index downloaded from AWS; if it exists there, return the URL
   specified there; if not, continue to next step
3. if this is a pre-Collection scene, then return the URL using our
   old method of parsing the scene ID fail with a "not found" error
4. The pre-Collection types are ["L1T", "L1GT", "L1G"], while the
   Collection-1 types are ["L1TP", "L1GT", "L1GS"]. This gives the
   necessary "fallthrough" behavior to correctly resolve L1GT assets.

Unit tests are included to verify this behavior.