### PR TITLE
Ignore Corrupt Landsat (-1 Cloud)

### DIFF
--- a/landsat_localindex/db/queries.go
+++ b/landsat_localindex/db/queries.go
@@ -45,6 +45,7 @@ func GetSceneByID(tx *sql.Tx, productID string) (*LandsatLocalIndexScene, error)
 }
 
 // SearchScenes does a lookup in indexed scenes based on a bounding box, cloud cover, and time window
+// Note: Any cloud cover that is <0 is usually corrupt in some way, and shall be excluded
 func SearchScenes(tx *sql.Tx, bbox geojson.BoundingBox, maxCloudCover float64, minAcquiredDate time.Time, maxAcquiredDate time.Time) ([]LandsatLocalIndexScene, error) {
 	rows, err := tx.Query(`
 		SELECT product_id, acquisition_date, cloud_cover, scene_url, ST_AsGeoJSON(bounds), 

--- a/landsat_localindex/db/queries.go
+++ b/landsat_localindex/db/queries.go
@@ -50,7 +50,7 @@ func SearchScenes(tx *sql.Tx, bbox geojson.BoundingBox, maxCloudCover float64, m
 		SELECT product_id, acquisition_date, cloud_cover, scene_url, ST_AsGeoJSON(bounds), 
 		       ST_AsGeoJSON(ST_MakePolygon(ST_MakeLine(ARRAY[corner_ul, corner_ur, corner_lr, corner_ll, corner_ul])))
 		FROM public.scenes
-		WHERE cloud_cover != -1
+		WHERE cloud_cover >= 0
 			AND cloud_cover < $1
 			AND acquisition_date > $2
 			AND acquisition_date < $3

--- a/landsat_localindex/db/queries.go
+++ b/landsat_localindex/db/queries.go
@@ -50,7 +50,8 @@ func SearchScenes(tx *sql.Tx, bbox geojson.BoundingBox, maxCloudCover float64, m
 		SELECT product_id, acquisition_date, cloud_cover, scene_url, ST_AsGeoJSON(bounds), 
 		       ST_AsGeoJSON(ST_MakePolygon(ST_MakeLine(ARRAY[corner_ul, corner_ur, corner_lr, corner_ll, corner_ul])))
 		FROM public.scenes
-		WHERE cloud_cover < $1
+		WHERE cloud_cover != -1
+			AND cloud_cover < $1
 			AND acquisition_date > $2
 			AND acquisition_date < $3
 			AND corner_ll IS NOT NULL 


### PR DESCRIPTION
Landsat images that report a -1 cloud cover are always corrupted. See examples such as https://s3-us-west-2.amazonaws.com/landsat-pds/L8/137/206/LC81372062014041LGN00/index.html
These images will cause the algorithm to fail. This PR updates the query such that those images are never returned in the search results. 