### PR TITLE
Add sentinel from planet as imagery source

### DIFF
--- a/planet/model.go
+++ b/planet/model.go
@@ -1,6 +1,8 @@
 package planet
 
 import (
+	"log"
+
 	"github.com/venicegeo/bf-ia-broker/util"
 	"github.com/venicegeo/geojson-go/geojson"
 )
@@ -124,7 +126,33 @@ type planetRequestInput struct {
 
 // MetadataOptions are the options for the Asset func
 type MetadataOptions struct {
-	ID       string
-	Tides    bool
-	ItemType string
+	ID            string
+	Tides         bool
+	ItemType      string
+	ImagerySource ImagerySource
+}
+
+// ImagerySource is an enum of all possible Planet imagery sources
+type ImagerySource uint64
+
+const (
+	_ ImagerySource = iota
+	rapidEye
+	planetScope
+	// landsatFromPlanet // Not supported
+	landsatFromS3
+	sentinelFromPlanet
+	sentinelFromS3
+)
+
+func imagerySourceRequiresActivation(imagerySource ImagerySource) bool {
+	switch imagerySource {
+	case rapidEye, planetScope, sentinelFromPlanet:
+		return true
+	case landsatFromS3, sentinelFromS3:
+		return false
+	default:
+		log.Print("Unrecognized imagery source, assuming activation needed")
+		return true
+	}
 }

--- a/planet/planet.go
+++ b/planet/planet.go
@@ -156,7 +156,7 @@ func GetPlanetAssets(options MetadataOptions, context *Context) (*model.PlanetAs
 	log.Print(assetMetadata)
 	log.Print(err)
 
-	if err == nil && itemTypeRequiresActivation(options.ItemType) {
+	if err == nil && imagerySourceRequiresActivation(options.ImagerySource) {
 		if assetMetadata == nil {
 			err = errors.New("Found no asset data in response for item type requiring asset activation")
 		} else if assetMetadata.ActivationURL.String() == "" {
@@ -295,15 +295,4 @@ func planetRequest(input planetRequestInput, context *Context) (*http.Response, 
 	util.LogAudit(context, util.LogAuditInput{Actor: "planet/doRequest", Action: input.method, Actee: inputURL, Message: message, Severity: util.INFO})
 	util.LogAudit(context, util.LogAuditInput{Actor: inputURL, Action: input.method + " response", Actee: "planet/doRequest", Message: "Receiving data from Planet API", Severity: util.INFO})
 	return util.HTTPClient().Do(request)
-}
-
-func itemTypeRequiresActivation(itemType string) bool {
-	switch itemType {
-	case "REOrthoTile":
-		fallthrough
-	case "PSOrthoTile":
-		return true
-	default:
-		return false
-	}
 }


### PR DESCRIPTION
The 'sentinel' imagery source no longer exists. It has been replaced by
'sentinel-planet' and 'sentinel-s3', which follow different code paths.

This may require further testing, as it is unclear whether Planet returns
Sentinel-2 imagery in the expected GeoTIFF (as they do everything else)
or in the native JPEG2000 that Sentinel-2 publishes imagery.