### PR TITLE
Remove Vacuum

### DIFF
--- a/migrations/00003_update_bounds_no_wrs.go
+++ b/migrations/00003_update_bounds_no_wrs.go
@@ -40,7 +40,6 @@ func Up00003(tx *sql.Tx) error {
 		WHERE corner_ll IS NOT NULL
 	) AS q1 
 	WHERE product_id = q1.pid;
-	VACUUM ANALYZE scenes;
 	`)
 	return err
 }


### PR DESCRIPTION
The VACUUM call is not necessary; and also causes the Docker environment to fail. Removing it. 